### PR TITLE
Fix compile issues & Discord RPC

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.13)
 project(runner LANGUAGES CXX)
+add_compile_options(-Wno-error=deprecated-declarations)
+add_compile_options(-Wno-deprecated-declarations)
+
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,6 +113,10 @@ dev_dependencies:
   envied_generator: ^1.0.0
   flutter_launcher_icons: ^0.14.4
 
+dependency_overrides:
+  flutter_rust_bridge: 2.11.1
+
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
Does a simple package downgrade to fix the discord RPC package being broken by the rust bridge. 
This also includes a very simple fix for linux compile issues.